### PR TITLE
Fixed typo in door description

### DIFF
--- a/MoreDoors/Resources/Data/doors.json
+++ b/MoreDoors/Resources/Data/doors.json
@@ -490,7 +490,7 @@
       "RightLocation": {
         "SceneName": "Fungus3_02",
         "GateName": "right2",
-        "NoKeyDesc": "A grand door, etched with the tails of a distant, forgotten city.",
+        "NoKeyDesc": "A grand door, etched with the tales of a distant, forgotten city.",
         "KeyDesc": "The pilgrim's way unfolds.<br>Insert the Canyon Key?",
         "Masks": [
           {


### PR DESCRIPTION
Door description references "tails" of a distant city instead of properly "tales".